### PR TITLE
use a secure version of requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 PyYAML==3.12
-requests==2.18.4
+requests>=2.20.0
 Jinja2==2.10
 multidict==4.3.1


### PR DESCRIPTION
See: https://nvd.nist.gov/vuln/detail/CVE-2018-18074

The Requests package through 2.19.1 before 2018-09-14 for Python sends an HTTP Authorization header to an http URI upon receiving a same-hostname https-to-http redirect, which makes it easier for remote attackers to discover credentials by sniffing the network.